### PR TITLE
fix for bolt.Path.getNorm on Python 2.7.8

### DIFF
--- a/Mopy/mash/bolt.py
+++ b/Mopy/mash/bolt.py
@@ -213,8 +213,8 @@ class Path(object):
     @staticmethod
     def getNorm(name):
         """Return the normpath for specified name/path object."""
-        if not name: return name
-        elif isinstance(name,Path): return name._s
+        if isinstance(name,Path): return name._s
+        elif not name: return name
         else: return os.path.normpath(name)
 
     @staticmethod


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "C:\Games\Bethesda Softworks\Morrowind\Mopy\mash\masher.py", line 2379, in OnShowPage
    self.GetPage(event.GetSelection()).OnShow()
  File "C:\Games\Bethesda Softworks\Morrowind\Mopy\mash\masher.py", line 2006, in OnShow
    modified = data.refresh(progress,what,self.fullRefresh)
  File "C:\Games\Bethesda Softworks\Morrowind\Mopy\mash\mosh.py", line 4250, in refresh
    settings['bash.installers.removeEmptyDirs'], fullRefresh)
  File "C:\Games\Bethesda Softworks\Morrowind\Mopy\mash\mosh.py", line 3612, in refreshSizeCrcDate
    rpFile = rpDir.join(sFile)
  File "C:\Games\Bethesda Softworks\Morrowind\Mopy\mash\bolt.py", line 385, in join
    return GPath(os.path.join(*norms))
  File "C:\Python27\lib\ntpath.py", line 86, in join
    if (result_path and result_path[0] not in '\\/' and
TypeError: 'Path' object does not support indexing
```

Currently the Oblivion and Skyrim versions are undergoing code updates and refactoring.  Because of that 2.7.8 is now required.  That will prevent the Morrowind version from working without this change.

[Python 2.7.8](https://www.python.org/download/releases/2.7.8/)
[wxPython 2.8.12.1 unicode for Python 2.7](http://sourceforge.net/projects/wxpython/files/wxPython/2.8.12.1/wxPython2.8-win32-unicode-2.8.12.1-py27.exe)
[comtypes 0.6.2](http://sourceforge.net/projects/comtypes/files/comtypes/0.6.2/comtypes-0.6.2.win32.exe/download)
[PyWin32-218 for Python 2.7](http://sourceforge.net/projects/pywin32/files/pywin32/Build)

I tested the installers tab and I was able to install a mod.  I will be making other changes as errors are reported in the [Wrye Mash](http://forums.bethsoft.com/topic/1449775-wrye-mash-thread-6/?p=23719696) thread.
